### PR TITLE
Alterando versão testada do wordpress

### DIFF
--- a/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -191,7 +191,7 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.9";
+        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.0";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -169,7 +169,7 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.9";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.0";
         $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -264,7 +264,7 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
-            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.7.9";
+            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.0";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
 			$params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-pix-gateway.php
+++ b/class-wc-yapay_intermediador-pix-gateway.php
@@ -186,7 +186,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.9";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.0";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-tef-gateway.php
+++ b/class-wc-yapay_intermediador-tef-gateway.php
@@ -205,7 +205,7 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.7.9";
+		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.0";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Integração Vindi, aguiart0, apiki
 Tags: woocommerce, vindi, intermediador, Vindi Pagamento, payment
 Requires at least: 3.5
-Tested up to: 6.4
-Stable tag: 0.7.9
+Tested up to: 6.8
+Stable tag: 0.8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,9 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
+= 0.8.0 = 23/04/2025
+* Fix: Testado na nova versão do Wordpress
+
 = 0.7.9 = 03/12/2024
 * Feature: Transferência bancária removida.
 * Fix: Correção do regex visa.

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -5,7 +5,7 @@
  * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
  * Author: Integração Vindi Intermediador
  * Author URI: https://vindi.com.br/
- * Version: 0.7.9
+ * Version: 0.8.0
  * Text Domain: vindi-pagamento
  */
 


### PR DESCRIPTION
## WooCommerce Vindi Payment Gateway
Atualização de compatibilidade do plugin com a versão mais recente do WordPress.

## Alterações
- Atualizado o campo `Tested up to` para `6.8` no arquivo principal do plugin e no `readme.txt`.


## Detalhes técnicos
Essa atualização não altera funcionalidades do plugin. Apenas sinaliza que o plugin foi testado com a versão `6.8` do WordPress, evitando alertas de compatibilidade no painel administrativo.


## Compatibilidade
- WordPress: `Tested up to: 6.8`
