### PR TITLE
Corrigir fluxo de pagamento para transações com falha

### DIFF
--- a/class-wc-yapay_intermediador-bankslip-gateway.php
+++ b/class-wc-yapay_intermediador-bankslip-gateway.php
@@ -191,7 +191,7 @@ class WC_Yapay_Intermediador_Bankslip_Gateway extends WC_Payment_Gateway
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
+        $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-bolepix-gateway.php
+++ b/class-wc-yapay_intermediador-bolepix-gateway.php
@@ -169,7 +169,7 @@ class WC_Yapay_Intermediador_Bolepix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.2";
         $params["customer[name]"] = substr($_POST["billing_first_name"] . " " . $_POST["billing_last_name"], 0 , 50);
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -61,7 +61,6 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             if (is_admin()) {
                 add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
             }
-
         } // End __construct()
 
         // Build the administration fields for this specific Gateway
@@ -261,12 +260,12 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             if ($reseller_token) {
                 $params["reseller_token"] = $reseller_token;
             }
-            
+
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
             $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
-			$params["customer[cpf]"] = $_POST["billing_cpf"];
+            $params["customer[cpf]"] = $_POST["billing_cpf"];
 
             if (!isset($_POST["billing_persontype"]) && !isset($_POST["billing_cpf"]) || $_POST["billing_persontype"] == 2) {
                 $params["customer[trade_name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
@@ -420,43 +419,68 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
             $tcResponse = $tcRequest->requestData("v2/transactions/pay_complete", $params, $this->get_option("environment"), false);
 
             if ($tcResponse->message_response->message == "success") {
+                if (
+                    isset($tcResponse->data_response->transaction->status_id) &&
+                    $tcResponse->data_response->transaction->status_id == 6
+                ) {
 
-                $transactionParams["order_id"]          = (string)$tcResponse->data_response->transaction->order_number;
-                $transactionParams["transaction_id"]    = (int)$tcResponse->data_response->transaction->transaction_id;
-                $transactionParams["split_number"]      = (int)$tcResponse->data_response->transaction->payment->split;
-                $transactionParams["payment_method"]    = (int)$tcResponse->data_response->transaction->payment->payment_method_id;
-                $transactionParams["token_transaction"] = (string)$tcResponse->data_response->transaction->token_transaction;
+                    $transactionParams["order_id"]          = (string)$tcResponse->data_response->transaction->order_number;
+                    $transactionParams["transaction_id"]    = (int)$tcResponse->data_response->transaction->transaction_id;
+                    $transactionParams["split_number"]      = (int)$tcResponse->data_response->transaction->payment->split;
+                    $transactionParams["payment_method"]    = (int)$tcResponse->data_response->transaction->payment->payment_method_id;
+                    $transactionParams["token_transaction"] = (string)$tcResponse->data_response->transaction->token_transaction;
 
+                    $order->update_meta_data('yapay_transaction_data', serialize($transactionParams));
+                    $order->save();
 
-                $order->update_meta_data('yapay_transaction_data', serialize($transactionParams));
-                $order->save();
+                    $log = new WC_Logger();
+                    $log->add(
+                        "yapay-intermediador-transactions-save-",
+                        "Vindi NEW TRANSACTION SAVE : \n" .
+                            print_r($transactionParams, true) . "\n\n"
+                    );
 
-                $log = new WC_Logger();
-                $log->add(
-                    "yapay-intermediador-transactions-save-",
-                    "Vindi NEW TRANSACTION SAVE : \n" .
-                        print_r($transactionParams, true) . "\n\n"
-                );
+                    if (defined('WC_VERSION') && version_compare(WC_VERSION, '2.1', '>=')) {
+                        WC()->cart->empty_cart();
+                    } else {
+                        $woocommerce->cart->empty_cart();
+                    }
 
-                if (defined('WC_VERSION') && version_compare(WC_VERSION, '2.1', '>=')) {
-                    WC()->cart->empty_cart();
-                } else {
-                    $woocommerce->cart->empty_cart();
-                }
-                if (!isset($use_shipping)) {
-                    $use_shipping = isset($use_shipping);
-                }
-                if (defined('WC_VERSION') && version_compare(WC_VERSION, '2.1', '>=')) {
+                    if (!isset($use_shipping)) {
+                        $use_shipping = isset($use_shipping);
+                    }
+
                     return array(
                         'result'   => 'success',
                         'redirect' => $this->get_return_url($order)
-                        // 'redirect' => add_query_arg( array( 'use_shipping' => $use_shipping ), $order->get_checkout_payment_url( true ) )
                     );
                 } else {
+                    $transactionParams["order_id"]          = (string)$tcResponse->data_response->transaction->order_number;
+                    $transactionParams["transaction_id"]    = (int)$tcResponse->data_response->transaction->transaction_id;
+                    $transactionParams["split_number"]      = (int)$tcResponse->data_response->transaction->payment->split;
+                    $transactionParams["payment_method"]    = (int)$tcResponse->data_response->transaction->payment->payment_method_id;
+                    $transactionParams["token_transaction"] = (string)$tcResponse->data_response->transaction->token_transaction;
+
+                    $order->update_meta_data('yapay_transaction_data', serialize($transactionParams));
+                    $order->update_status('failed', __('Pagamento não aprovado na Vindi. Status: ', 'wc-yapay_intermediador-cc') .
+                        $tcResponse->data_response->transaction->status_id . ' - ' .
+                        $tcResponse->data_response->transaction->status_name);
+                    $order->save();
+
+                    $errorMsg = __("Pagamento processado mas não aprovado. Status: ", 'wc-yapay_intermediador-cc') .
+                        $tcResponse->data_response->transaction->status_id . " - " .
+                        $tcResponse->data_response->transaction->status_name;
+
+                    $this->add_error(array($errorMsg));
+
+                    if (defined('WC_VERSION') && version_compare(WC_VERSION, '3.0', '>=')) {
+                        WC()->session->set('order_awaiting_payment', false);
+                    } else {
+                        unset(WC()->session->order_awaiting_payment);
+                    }
+
                     return array(
-                        'result'   => 'success',
-                        'redirect' => $this->get_return_url($order)
-                        // 'redirect' => add_query_arg( array( 'order' => $order->id, 'key' => $order->order_key, 'use_shipping' => $use_shipping ), get_permalink( woocommerce_get_page_id( 'pay' ) ) )
+                        'result'   => 'failure'
                     );
                 }
             } else {
@@ -472,7 +496,20 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
                 } else {
                     $errors[] = "<strong>Código:</strong> 9999 | <strong>Mensagem:</strong> Não foi possível finalizar o pedido. Tente novamente mais tarde!";
                 }
+
+                $order->update_status('failed', __('Erro na comunicação com Vindi', 'wc-yapay_intermediador-cc'));
+
                 $this->add_error($errors);
+
+                if (defined('WC_VERSION') && version_compare(WC_VERSION, '3.0', '>=')) {
+                    WC()->session->set('order_awaiting_payment', false);
+                } else {
+                    unset(WC()->session->order_awaiting_payment);
+                }
+
+                return array(
+                    'result'   => 'failure'
+                );
             }
         }
 

--- a/class-wc-yapay_intermediador-creditcard-gateway.php
+++ b/class-wc-yapay_intermediador-creditcard-gateway.php
@@ -263,7 +263,7 @@ if (!class_exists('WC_Yapay_Intermediador_Creditcard_Gateway')) :
 
             $params["token_account"] = $this->get_option("token_account");
             $params["finger_print"] = $_POST["finger_print"];
-            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
+            $params['transaction[free]'] = "WOOCOMMERCE_INTERMEDIADOR_v0.8.2";
             $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
             $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-pix-gateway.php
+++ b/class-wc-yapay_intermediador-pix-gateway.php
@@ -186,7 +186,7 @@ class WC_Yapay_Intermediador_Pix_Gateway extends WC_Payment_Gateway {
         
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
+		    $params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/class-wc-yapay_intermediador-tef-gateway.php
+++ b/class-wc-yapay_intermediador-tef-gateway.php
@@ -205,7 +205,7 @@ class WC_Yapay_Intermediador_Tef_Gateway extends WC_Payment_Gateway {
 
         $params["token_account"] = $this->get_option("token_account");
         $params["finger_print"] = $_POST["finger_print"];
-		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.1";
+		$params['transaction[free]']= "WOOCOMMERCE_INTERMEDIADOR_v0.8.2";
         $params["customer[name]"] = $_POST["billing_first_name"] . " " . $_POST["billing_last_name"];
         $params["customer[cpf]"] = $_POST["billing_cpf"];
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
-= 0.8.2 = 02/06/2025
+= 0.8.2 = 10/06/2025
 * Fix: Melhoria no fluxo de pagamento via cartão de credito.
 
 = 0.8.1 = 02/06/2025

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Integração Vindi, aguiart0, apiki
 Tags: woocommerce, vindi, intermediador, Vindi Pagamento, payment
 Requires at least: 3.5
 Tested up to: 6.8
-Stable tag: 0.8.1
+Stable tag: 0.8.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,9 @@ Para dúvidas envie um e-mail para nosso time de Integração: integracao@yapay.
 2. Página de configuração do plugin
 
 == Changelog ==
+= 0.8.2 = 02/06/2025
+* Fix: Melhoria no fluxo de pagamento via cartão de credito.
+
 = 0.8.1 = 02/06/2025
 * Security: Implementação da sanitização de dados nos logs de requisição
 

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -5,7 +5,7 @@
  * Description: Intermediador de pagamento Vindi para a plataforma WooCommerce.
  * Author: Integração Vindi Intermediador
  * Author URI: https://vindi.com.br/
- * Version: 0.8.1
+ * Version: 0.8.2
  * Text Domain: vindi-pagamento
  */
 
@@ -468,7 +468,7 @@ function check_plugin_dependencies() {
 add_action( 'admin_init', 'check_plugin_dependencies' );
 
 function wc_yapay_intermediador_version_check() {
-    $current_version = '0.8.1';
+    $current_version = '0.8.2';
     $stored_version = get_option('wc_yapay_intermediador_version');
     
     if ($stored_version !== $current_version) {

--- a/wc-yapay_intermediador.php
+++ b/wc-yapay_intermediador.php
@@ -451,7 +451,7 @@ function yapay_enqueue_scripts() {
         wp_enqueue_script(
             'yapay_intermediador-fingerprint',
             'https://static.traycheckout.com.br/js/finger_print.js',
-            ['jquery', 'yapay_intermediador-checkout'],
+            ['jquery', 'yapay_intermediador-checkout-credit'],
         );
     }
 }


### PR DESCRIPTION
## **Descrição**

Esta atualização corrige um problema no fluxo de pagamento onde os clientes estavam sendo incorretamente redirecionados para a página de agradecimento mesmo quando a transação de pagamento não era aprovada no sandbox. Implementamos as seguintes melhorias:

- Adicionamos verificação do código de status da transação (`status_id`) para garantir que apenas transações com status 6 (aprovado) sejam redirecionadas para a página de sucesso
- Atualizamos automaticamente o status do pedido para "falha" quando o pagamento é recusado ou fica pendente
- Implementamos tratamento adequado para transações que foram processadas mas não aprovadas
- Limpamos os dados de sessão do WooCommerce para permitir a criação de um novo pedido após falha no pagamento
- Adicionamos mensagens de erro detalhadas para informar os clientes sobre problemas no pagamento
- Corrigimos o problema onde os números de pedido estavam sendo "consumidos" mesmo quando os pagamentos falhavam

# **Como testar**
1. **Teste de pagamento bem-sucedido**:
    - Faça uma compra utilizando os dados de cartão de teste que geram aprovação
    - Verifique se você é redirecionado para a página de agradecimento
    - Confirme se o status do pedido está como "processando" ou "concluído"
2. **Teste de pagamento recusado**:
    - Faça uma compra utilizando dados de cartão de teste que geram recusa (como número 4444 4444 4444 4448)
    - Verifique se você permanece na página de checkout
    - Confirme se uma mensagem de erro clara é exibida informando sobre a recusa
    - Observe que o status do pedido deve estar como "falha"
3. **Teste de continuidade após falha**:
    - Após uma transação recusada, tente realizar uma nova compra
    - Verifique se um novo número de pedido é gerado (o anterior não deve ser reutilizado)
    - Complete o pagamento com um cartão válido
    - Confirme se o novo pedido é processado corretamente
4. **Verificação de logs**:
    - Acesse WooCommerce > Status > Logs
    - Procure por entradas com "yapay-intermediador"
    - Verifique se há registros claros tanto para transações bem-sucedidas quanto para falhas